### PR TITLE
Remove duplicate ids causing bad logs in Neon 1

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath.ui/templates/xpath_templates.xml
+++ b/bundles/org.eclipse.wst.xml.xpath.ui/templates/xpath_templates.xml
@@ -97,10 +97,6 @@
 	          enabled="true" name="lang(string)">lang(${cursor})</template>
 	<template id="org.eclipse.wst.xslt.templates.xpath.number"
 	          autoinsert="true" context="xsl_xpath" deleted="false"
-	          description='Returns a boolean false value.'
-	          enabled="true" name="number(arg)">number(${cursor})</template>
-	<template id="org.eclipse.wst.xslt.templates.xpath.number"
-	          autoinsert="true" context="xsl_xpath" deleted="false"
 	          description='Returns the numeric value of the argument. The argument could be a boolean, string, or node-set.'
 	          enabled="true" name="number(arg)">number(${cursor})</template>
 	<template id="org.eclipse.wst.xslt.templates.xpath.sum"
@@ -115,10 +111,6 @@
 	          autoinsert="true" context="xsl_xpath" deleted="false"
 	          description='The ceiling function returns the smallest (closest to negative infinity) number that is not less than the argument and that is an integer.'
 	          enabled="true" name="ceiling(number)">ceiling(${cursor})</template>
-	<template id="org.eclipse.wst.xslt.templates.xpath.round"
-	          autoinsert="true" context="xsl_xpath" deleted="false"
-	          description='The round function returns the number that is closest to the argument and that is an integer. If there are two such numbers, then the one that is closest to positive infinity is returned. If the argument is NaN, then NaN is returned. If the argument is positive infinity, then positive infinity is returned. If the argument is negative infinity, then negative infinity is returned. If the argument is positive zero, then positive zero is returned. If the argument is negative zero, then negative zero is returned. If the argument is less than zero, but greater than or equal to -0.5, then negative zero is returned.'
-	          enabled="true" name="round(number)">round(${cursor})</template>
 	<template id="org.eclipse.wst.xslt.templates.xpath.round"
 	          autoinsert="true" context="xsl_xpath" deleted="false"
 	          description='The round function returns the number that is closest to the argument and that is an integer. If there are two such numbers, then the one that is closest to positive infinity is returned. If the argument is NaN, then NaN is returned. If the argument is positive infinity, then positive infinity is returned. If the argument is negative infinity, then negative infinity is returned. If the argument is positive zero, then positive zero is returned. If the argument is negative zero, then negative zero is returned. If the argument is less than zero, but greater than or equal to -0.5, then negative zero is returned.'


### PR DESCRIPTION
Remove duplicate ids : org.eclipse.wst.xslt.templates.xpath.round, and org.eclipse.wst.xslt.templates.xpath.number.
In Eclipse Neon 1, they seem to cause these logs (when openning Preferences Window) :

!ENTRY org.eclipse.jface.text 2 0 2016-10-03 18:38:42.892
!MESSAGE Duplicate template id: 'org.eclipse.wst.xslt.templates.xpath.number'
!ENTRY org.eclipse.jface.text 2 0 2016-10-03 18:38:42.902
!MESSAGE Duplicate template id: 'org.eclipse.wst.xslt.templates.xpath.round'